### PR TITLE
Fix (are -> care) typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ minutes.
 
 BERT is method of pre-training language representations, meaning that we train a
 general-purpose "language understanding" model on a large text corpus (like
-Wikipedia), and then use that model for downstream NLP tasks that we are about
+Wikipedia), and then use that model for downstream NLP tasks that we care about
 (like question answering). BERT outperforms previous methods because it is the
 first *unsupervised*, *deeply bidirectional* system for pre-training NLP.
 


### PR DESCRIPTION
Thanks for BERT!
Just a minor fix in README.md
 NLP tasks that we **are** about -> care
I have already signed the Google open source contribution agreement 