### PR TITLE
Add predictor for fine tuned classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ that it's running on something other than a Cloud TPU, which includes a GPU.
 
 #### Prediction from classifier
 Once you have trained your classifier you can use it in inference mode by using the --do_predict=true command.
-You need to have a file named predict.tsv in the input folder. 
-Output will be created in file called predict_results.tsv in the output folder.
+You need to have a file named test.tsv in the input folder. 
+Output will be created in file called test_results.tsv in the output folder.
 Each line will contain output for each sample, columns are the class probabilities.
 ```shell
 export BERT_BASE_DIR=/path/to/bert/uncased_L-12_H-768_A-12

--- a/multilingual.md
+++ b/multilingual.md
@@ -29,7 +29,7 @@ XNLI, not Google NMT). For clarity, we only report on 6 languages below:
 | System                          | English  | Chinese  | Spanish  | German   | Arabic   | Urdu     |
 | ------------------------------- | -------- | -------- | -------- | -------- | -------- | -------- |
 | XNLI Baseline - Translate Train | 73.7     | 67.0     | 68.8     | 66.5     | 65.8     | 56.6     |
-| XNLI Baseline - Translate       | 73.7     | 68.3     | 70.7     | 68.7     | 66.8     | 59.3     |
+| XNLI Baseline - Translate Test  | 73.7     | 68.3     | 70.7     | 68.7     | 66.8     | 59.3     |
 | BERT -Translate Train           | **81.4** | **74.2** | **77.3** | **75.2** | **70.5** | 61.7     |
 | BERT - Translate Test           | 81.4     | 70.1     | 74.9     | 74.4     | 70.4     | **62.1** |
 | BERT - Zero Shot                | 81.4     | 63.8     | 74.3     | 70.5     | 62.1     | 58.3     |

--- a/multilingual.md
+++ b/multilingual.md
@@ -51,9 +51,10 @@ foreign language into English. So training and evaluation were both done on
 English. However, test evaluation was done on machine-translated English, so the
 accuracy depends on the quality of the machine translation system.
 
-**Zero Shot** means that the system was trained on English, and then evaluated
-on the foreign language. In this case, machine translation was not involved at
-all in either the pre-training or fine-tuning.
+**Zero Shot** means that the Multilingual BERT system was fine-tuned on English
+MultiNLI, and then evaluated on the foreign language XNLI test. In this case,
+machine translation was not involved at all in either the pre-training or
+fine-tuning.
 
 Note that the English result is worse than the 84.2 MultiNLI baseline because
 this training used Multilingual BERT rather than English-only BERT. This implies

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -772,35 +772,35 @@ def main(_):
         tf.logging.info("  %s = %s", key, str(result[key]))
         writer.write("%s = %s\n" % (key, str(result[key])))
   if FLAGS.do_predict:
-      predict_examples = processor.get_predict_examples(FLAGS.data_dir)
-      predict_file = os.path.join(FLAGS.output_dir, "predict.tf_record")
-      convert_examples_to_features(predict_examples, label_list,
-                                   FLAGS.max_seq_length, tokenizer, predict_file)
+    predict_examples = processor.get_predict_examples(FLAGS.data_dir)
+    predict_file = os.path.join(FLAGS.output_dir, "predict.tf_record")
+    convert_examples_to_features(predict_examples, label_list,
+                                 FLAGS.max_seq_length, tokenizer, predict_file)
 
-      tf.logging.info("***** Running prediction*****")
-      tf.logging.info("  Num examples = %d", len(predict_examples))
-      tf.logging.info("  Batch size = %d", FLAGS.predict_batch_size)
+    tf.logging.info("***** Running prediction*****")
+    tf.logging.info("  Num examples = %d", len(predict_examples))
+    tf.logging.info("  Batch size = %d", FLAGS.predict_batch_size)
 
-      if FLAGS.use_tpu:
-        # Warning: According to tpu_estimator.py Prediction on TPU is an experimental feature and hence
-        # not supported here
-        raise ValueError('Prediction in TPU not supported')
+    if FLAGS.use_tpu:
+      # Warning: According to tpu_estimator.py Prediction on TPU is an experimental feature and hence
+      # not supported here
+      raise ValueError('Prediction in TPU not supported')
 
-      predict_drop_remainder = True if FLAGS.use_tpu else False
-      predict_input_fn = input_fn_builder(
-          input_file=predict_file,
-          seq_length=FLAGS.max_seq_length,
-          is_training=False,
-          drop_remainder=predict_drop_remainder)
+    predict_drop_remainder = True if FLAGS.use_tpu else False
+    predict_input_fn = input_fn_builder(
+      input_file=predict_file,
+      seq_length=FLAGS.max_seq_length,
+      is_training=False,
+      drop_remainder=predict_drop_remainder)
 
-      result = estimator.predict(input_fn=predict_input_fn)
+    result = estimator.predict(input_fn=predict_input_fn)
 
-      output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.tsv")
-      with tf.gfile.GFile(output_predict_file, "w") as writer:
-          tf.logging.info("***** Predict results *****")
-          for prediction in result:
-              output_line = '\t'.join(str(class_probability) for class_probability in prediction) + '\n'
-              writer.write(output_line)
+    output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.tsv")
+    with tf.gfile.GFile(output_predict_file, "w") as writer:
+      tf.logging.info("***** Predict results *****")
+      for prediction in result:
+        output_line = '\t'.join(str(class_probability) for class_probability in prediction) + '\n'
+        writer.write(output_line)
 
 if __name__ == "__main__":
   flags.mark_flag_as_required("data_dir")

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -781,13 +781,9 @@ def main(_):
       tf.logging.info("  Num examples = %d", len(predict_examples))
       tf.logging.info("  Batch size = %d", FLAGS.predict_batch_size)
 
-      # This tells the estimator to run through the entire set.
-      predict_steps = None
-      # However, if running predict on the TPU, you will need to specify the
-      # number of steps.
       if FLAGS.use_tpu:
         # Warning: According to tpu_estimator.py Prediction on TPU is an experimental feature and hence
-        # supported here
+        # not supported here
         raise ValueError('Prediction in TPU not supported')
 
       predict_drop_remainder = True if FLAGS.use_tpu else False

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -799,7 +799,7 @@ def main(_):
 
       result = estimator.predict(input_fn=predict_input_fn)
 
-      output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.txt")
+      output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.tsv")
       with tf.gfile.GFile(output_predict_file, "w") as writer:
           tf.logging.info("***** Predict results *****")
           for prediction in result:

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -71,9 +71,13 @@ flags.DEFINE_bool("do_train", False, "Whether to run training.")
 
 flags.DEFINE_bool("do_eval", False, "Whether to run eval on the dev set.")
 
+flags.DEFINE_bool("do_predict", False, "Whether to run the model in inference mode on predict set.")
+
 flags.DEFINE_integer("train_batch_size", 32, "Total batch size for training.")
 
 flags.DEFINE_integer("eval_batch_size", 8, "Total batch size for eval.")
+
+flags.DEFINE_integer("predict_batch_size", 8, "Total batch size for predict.")
 
 flags.DEFINE_float("learning_rate", 5e-5, "The initial learning rate for Adam.")
 
@@ -475,6 +479,7 @@ def create_model(bert_config, is_training, input_ids, input_mask, segment_ids,
 
     logits = tf.matmul(output_layer, output_weights, transpose_b=True)
     logits = tf.nn.bias_add(logits, output_bias)
+    probabilities = tf.nn.softmax(logits, axis=-1)
     log_probs = tf.nn.log_softmax(logits, axis=-1)
 
     one_hot_labels = tf.one_hot(labels, depth=num_labels, dtype=tf.float32)
@@ -482,7 +487,7 @@ def create_model(bert_config, is_training, input_ids, input_mask, segment_ids,
     per_example_loss = -tf.reduce_sum(one_hot_labels * log_probs, axis=-1)
     loss = tf.reduce_mean(per_example_loss)
 
-    return (loss, per_example_loss, logits)
+    return (loss, per_example_loss, logits, probabilities)
 
 
 def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
@@ -504,7 +509,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
 
     is_training = (mode == tf.estimator.ModeKeys.TRAIN)
 
-    (total_loss, per_example_loss, logits) = create_model(
+    (total_loss, per_example_loss, logits, probabilities) = create_model(
         bert_config, is_training, input_ids, input_mask, segment_ids, label_ids,
         num_labels, use_one_hot_embeddings)
 
@@ -562,8 +567,10 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
           eval_metrics=eval_metrics,
           scaffold_fn=scaffold_fn)
     else:
-      raise ValueError("Only TRAIN and EVAL modes are supported: %s" % (mode))
-
+      output_spec = tf.contrib.tpu.TPUEstimatorSpec(
+          mode=mode,
+          prediction=probabilities,
+          scaffold_fn=scaffold_fn)
     return output_spec
 
   return model_fn
@@ -625,8 +632,8 @@ def main(_):
       "xnli": XnliProcessor,
   }
 
-  if not FLAGS.do_train and not FLAGS.do_eval:
-    raise ValueError("At least one of `do_train` or `do_eval` must be True.")
+  if not FLAGS.do_train and not FLAGS.do_eval and not FLAGS.do_predict:
+    raise ValueError("At least one of `do_train`, `do_eval` or `do_predict' must be True.")
 
   bert_config = modeling.BertConfig.from_json_file(FLAGS.bert_config_file)
 
@@ -692,7 +699,8 @@ def main(_):
       model_fn=model_fn,
       config=run_config,
       train_batch_size=FLAGS.train_batch_size,
-      eval_batch_size=FLAGS.eval_batch_size)
+      eval_batch_size=FLAGS.eval_batch_size,
+      predict_batch_size=FLAGS.predict_batch_size)
 
   if FLAGS.do_train:
     train_file = os.path.join(FLAGS.output_dir, "train.tf_record")
@@ -743,7 +751,40 @@ def main(_):
       for key in sorted(result.keys()):
         tf.logging.info("  %s = %s", key, str(result[key]))
         writer.write("%s = %s\n" % (key, str(result[key])))
+  if FLAGS.do_predict:
+      predict_examples = processor.get_predict_examples(FLAGS.data_dir)
+      predict_file = os.path.join(FLAGS.output_dir, "predict.tf_record")
+      convert_examples_to_features(predict_examples, label_list,
+                                   FLAGS.max_seq_length, tokenizer, predict_file)
 
+      tf.logging.info("***** Running prediction*****")
+      tf.logging.info("  Num examples = %d", len(predict_examples))
+      tf.logging.info("  Batch size = %d", FLAGS.predict_batch_size)
+
+      # This tells the estimator to run through the entire set.
+      predict_steps = None
+      # However, if running predict on the TPU, you will need to specify the
+      # number of steps.
+      if FLAGS.use_tpu:
+        # Warning: According to tpu_estimator.py Prediction on TPU is an experimental feature and hence
+        # supported here
+        raise ValueError('Prediction in TPU not supported')
+
+      predict_drop_remainder = True if FLAGS.use_tpu else False
+      predict_input_fn = input_fn_builder(
+          input_file=predict_file,
+          seq_length=FLAGS.max_seq_length,
+          is_training=False,
+          drop_remainder=predict_drop_remainder)
+
+      result = estimator.predict(input_fn=predict_input_fn)
+
+      output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.txt")
+      with tf.gfile.GFile(output_predict_file, "w") as writer:
+          tf.logging.info("***** Predict results *****")
+          for prediction in result:
+              output_line = '\t'.join(class_probability for class_probability in prediction) + '\n'
+              writer.write(output_line)
 
 if __name__ == "__main__":
   flags.mark_flag_as_required("data_dir")

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -589,7 +589,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
     else:
       output_spec = tf.contrib.tpu.TPUEstimatorSpec(
           mode=mode,
-          prediction=probabilities,
+          predictions=probabilities,
           scaffold_fn=scaffold_fn)
     return output_spec
 
@@ -803,7 +803,7 @@ def main(_):
       with tf.gfile.GFile(output_predict_file, "w") as writer:
           tf.logging.info("***** Predict results *****")
           for prediction in result:
-              output_line = '\t'.join(class_probability for class_probability in prediction) + '\n'
+              output_line = '\t'.join(str(class_probability) for class_probability in prediction) + '\n'
               writer.write(output_line)
 
 if __name__ == "__main__":

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -71,7 +71,7 @@ flags.DEFINE_bool("do_train", False, "Whether to run training.")
 
 flags.DEFINE_bool("do_eval", False, "Whether to run eval on the dev set.")
 
-flags.DEFINE_bool("do_predict", False, "Whether to run the model in inference mode on predict set.")
+flags.DEFINE_bool("do_predict", False, "Whether to run the model in inference mode on the test set.")
 
 flags.DEFINE_integer("train_batch_size", 32, "Total batch size for training.")
 
@@ -164,7 +164,7 @@ class DataProcessor(object):
     """Gets a collection of `InputExample`s for the dev set."""
     raise NotImplementedError()
 
-  def get_predict_examples(self, data_dir):
+  def get_test_examples(self, data_dir):
     """Gets a collection of `InputExample`s for prediction."""
     raise NotImplementedError()
 
@@ -245,11 +245,11 @@ class MnliProcessor(DataProcessor):
         self._read_tsv(os.path.join(data_dir, "dev_matched.tsv")),
         "dev_matched")
 
-  def get_predict_examples(self, data_dir):
+  def get_test_examples(self, data_dir):
     """See base class."""
     return self._create_examples(
-      self._read_tsv(os.path.join(data_dir, "predict.tsv")),
-      "predict")
+      self._read_tsv(os.path.join(data_dir, "test_matched.tsv")),
+      "test")
 
   def get_labels(self):
     """See base class."""
@@ -283,10 +283,10 @@ class MrpcProcessor(DataProcessor):
     return self._create_examples(
         self._read_tsv(os.path.join(data_dir, "dev.tsv")), "dev")
 
-  def get_predict_examples(self, data_dir):
+  def get_test_examples(self, data_dir):
     """See base class."""
     return self._create_examples(
-      self._read_tsv(os.path.join(data_dir, "predict.tsv")), "predict")
+      self._read_tsv(os.path.join(data_dir, "test.tsv")), "test")
 
   def get_labels(self):
     """See base class."""
@@ -320,10 +320,10 @@ class ColaProcessor(DataProcessor):
     return self._create_examples(
         self._read_tsv(os.path.join(data_dir, "dev.tsv")), "dev")
 
-  def get_predict_examples(self, data_dir):
+  def get_test_examples(self, data_dir):
     """See base class."""
     return self._create_examples(
-      self._read_tsv(os.path.join(data_dir, "predict.tsv")), "predict")
+      self._read_tsv(os.path.join(data_dir, "test.tsv")), "test")
 
   def get_labels(self):
     """See base class."""
@@ -772,7 +772,7 @@ def main(_):
         tf.logging.info("  %s = %s", key, str(result[key]))
         writer.write("%s = %s\n" % (key, str(result[key])))
   if FLAGS.do_predict:
-    predict_examples = processor.get_predict_examples(FLAGS.data_dir)
+    predict_examples = processor.get_test_examples(FLAGS.data_dir)
     predict_file = os.path.join(FLAGS.output_dir, "predict.tf_record")
     convert_examples_to_features(predict_examples, label_list,
                                  FLAGS.max_seq_length, tokenizer, predict_file)
@@ -795,7 +795,7 @@ def main(_):
 
     result = estimator.predict(input_fn=predict_input_fn)
 
-    output_predict_file = os.path.join(FLAGS.output_dir, "predict_results.tsv")
+    output_predict_file = os.path.join(FLAGS.output_dir, "test_results.tsv")
     with tf.gfile.GFile(output_predict_file, "w") as writer:
       tf.logging.info("***** Predict results *****")
       for prediction in result:

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -164,6 +164,10 @@ class DataProcessor(object):
     """Gets a collection of `InputExample`s for the dev set."""
     raise NotImplementedError()
 
+  def get_predict_examples(self, data_dir):
+    """Gets a collection of `InputExample`s for prediction."""
+    raise NotImplementedError()
+
   def get_labels(self):
     """Gets the list of labels for this data set."""
     raise NotImplementedError()
@@ -241,6 +245,12 @@ class MnliProcessor(DataProcessor):
         self._read_tsv(os.path.join(data_dir, "dev_matched.tsv")),
         "dev_matched")
 
+  def get_predict_examples(self, data_dir):
+    """See base class."""
+    return self._create_examples(
+      self._read_tsv(os.path.join(data_dir, "predict.tsv")),
+      "predict")
+
   def get_labels(self):
     """See base class."""
     return ["contradiction", "entailment", "neutral"]
@@ -273,6 +283,11 @@ class MrpcProcessor(DataProcessor):
     return self._create_examples(
         self._read_tsv(os.path.join(data_dir, "dev.tsv")), "dev")
 
+  def get_predict_examples(self, data_dir):
+    """See base class."""
+    return self._create_examples(
+      self._read_tsv(os.path.join(data_dir, "predict.tsv")), "predict")
+
   def get_labels(self):
     """See base class."""
     return ["0", "1"]
@@ -304,6 +319,11 @@ class ColaProcessor(DataProcessor):
     """See base class."""
     return self._create_examples(
         self._read_tsv(os.path.join(data_dir, "dev.tsv")), "dev")
+
+  def get_predict_examples(self, data_dir):
+    """See base class."""
+    return self._create_examples(
+      self._read_tsv(os.path.join(data_dir, "predict.tsv")), "predict")
 
   def get_labels(self):
     """See base class."""


### PR DESCRIPTION
Added a predict command --do_predict to load fine tuned classifier and give out probabilities to be used in inference mode. Tested out in CPU with MRPC example. Created get_predict_examples for all data processors except XNLI. Can be added if needed. Predict is not supported with TPU mode. Added documentation to readme.