### PR TITLE
fix to model variable scope

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -169,7 +169,7 @@ class BertModel(object):
     if token_type_ids is None:
       token_type_ids = tf.zeros(shape=[batch_size, seq_length], dtype=tf.int32)
 
-    with tf.variable_scope("bert", scope):
+    with tf.variable_scope(scope, "bert"):
       with tf.variable_scope("embeddings"):
         # Perform embedding lookup on the word ids.
         (self.embedding_output, self.embedding_table) = embedding_lookup(

--- a/modeling.py
+++ b/modeling.py
@@ -169,7 +169,7 @@ class BertModel(object):
     if token_type_ids is None:
       token_type_ids = tf.zeros(shape=[batch_size, seq_length], dtype=tf.int32)
 
-    with tf.variable_scope(scope, "bert"):
+    with tf.variable_scope(scope, default_name="bert"):
       with tf.variable_scope("embeddings"):
         # Perform embedding lookup on the word ids.
         (self.embedding_output, self.embedding_table) = embedding_lookup(


### PR DESCRIPTION
I believe this fix is correct?

Currently we have:

```
with tf.variable_scope("bert", scope)
```

where the intention is that "bert" is default and "scope" take precedence if provided.

Based on https://www.tensorflow.org/api_docs/python/tf/variable_scope, it looks like, as-is, "bert" will always be used as scope, and 'scope' will never be used.

Swapping the two makes it so default_name="bert", as intended.  (The dangers of not assigning vars by name in python?)

Happy to delete if I've misread the API.

Alternately, we could just default scope='bert' at function definition...I was trying to apply minimal changes, however.