### PR TITLE
fix label_map key error in function `convert_single_example` in `run_classifier.py` when doing prediction

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -264,7 +264,10 @@ class MnliProcessor(DataProcessor):
       guid = "%s-%s" % (set_type, tokenization.convert_to_unicode(line[0]))
       text_a = tokenization.convert_to_unicode(line[8])
       text_b = tokenization.convert_to_unicode(line[9])
-      label = tokenization.convert_to_unicode(line[-1])
+      if set_type == "test":
+        label = "contradiction"
+      else:
+        label = tokenization.convert_to_unicode(line[-1])
       examples.append(
           InputExample(guid=guid, text_a=text_a, text_b=text_b, label=label))
     return examples
@@ -301,7 +304,10 @@ class MrpcProcessor(DataProcessor):
       guid = "%s-%s" % (set_type, i)
       text_a = tokenization.convert_to_unicode(line[3])
       text_b = tokenization.convert_to_unicode(line[4])
-      label = tokenization.convert_to_unicode(line[0])
+      if set_type == "test":
+        label = "0"
+      else:
+        label = tokenization.convert_to_unicode(line[0])
       examples.append(
           InputExample(guid=guid, text_a=text_a, text_b=text_b, label=label))
     return examples
@@ -335,7 +341,10 @@ class ColaProcessor(DataProcessor):
     for (i, line) in enumerate(lines):
       guid = "%s-%s" % (set_type, i)
       text_a = tokenization.convert_to_unicode(line[3])
-      label = tokenization.convert_to_unicode(line[1])
+      if set_type == "test":
+        label = "0"
+      else:
+        label = tokenization.convert_to_unicode(line[1])
       examples.append(
           InputExample(guid=guid, text_a=text_a, text_b=None, label=label))
     return examples
@@ -855,6 +864,7 @@ def main(_):
       for key in sorted(result.keys()):
         tf.logging.info("  %s = %s", key, str(result[key]))
         writer.write("%s = %s\n" % (key, str(result[key])))
+
   if FLAGS.do_predict:
     predict_examples = processor.get_test_examples(FLAGS.data_dir)
     predict_file = os.path.join(FLAGS.output_dir, "predict.tf_record")


### PR DESCRIPTION
An error arised when I tried to do prediction from classifier:

Traceback (most recent call last):
  File "run_classifier.py", line 896, in <module>
    tf.app.run()
  File "/root/virtualenvs/bert_py3/lib/python3.5/site-packages/tensorflow/python/platform/app.py", line 125, in run
    _sys.exit(main(argv))
  File "run_classifier.py", line 863, in main
    FLAGS.max_seq_length, tokenizer, predict_file)
  File "run_classifier.py", line 448, in file_based_convert_examples_to_features
    max_seq_length, tokenizer)
  File "run_classifier.py", line 418, in convert_single_example
    label_id = label_map[example.label]
KeyError: '2'

That's because the `test.tsv` does not have labels like `train.tsv` or `dev.tsv` does, but function `get_test_examples` uses `_create_examples` the same way as `train` or `dev` mode. So just need to give allowed labels(but won't be used for prediction) to test examples.