### PR TITLE
Add flag to extract only features for the [CLS] token

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -174,8 +174,7 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
 
     tvars = tf.trainable_variables()
     scaffold_fn = None
-    (assignment_map, initialized_variable_names
-    ) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)
+    (assignment_map, initialized_variable_names) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)
     if use_tpu:
 
       def tpu_scaffold():
@@ -185,14 +184,6 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
       scaffold_fn = tpu_scaffold
     else:
       tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
-
-    tf.logging.info("**** Trainable Variables ****")
-    for var in tvars:
-      init_string = ""
-      if var.name in initialized_variable_names:
-        init_string = ", *INIT_FROM_CKPT*"
-      tf.logging.info("  name = %s, shape = %s%s", var.name, var.shape,
-                      init_string)
 
     all_layers = model.get_all_encoder_layers()
 
@@ -285,8 +276,7 @@ def convert_examples_to_features(examples, seq_length, tokenizer):
     if ex_index < 5:
       tf.logging.info("*** Example ***")
       tf.logging.info("unique_id: %s" % (example.unique_id))
-      tf.logging.info("tokens: %s" % " ".join(
-          [tokenization.printable_text(x) for x in tokens]))
+      tf.logging.info("tokens: %s" % " ".join([tokenization.printable_text(x) for x in tokens]))
       tf.logging.info("input_ids: %s" % " ".join([str(x) for x in input_ids]))
       tf.logging.info("input_mask: %s" % " ".join([str(x) for x in input_mask]))
       tf.logging.info(

--- a/extract_features.py
+++ b/extract_features.py
@@ -277,7 +277,7 @@ def convert_examples_to_features(examples, seq_length, tokenizer):
     if ex_index < 5:
       tf.logging.info("*** Example ***")
       tf.logging.info("unique_id: %s" % (example.unique_id))
-      tf.logging.info("tokens: %s" % " ".join([tokenization.printable_text(x) for x in tokens]))
+      tf.logging.info("tokens: %s" % " ".join([str(x) for x in tokens]))
       tf.logging.info("input_ids: %s" % " ".join([str(x) for x in input_ids]))
       tf.logging.info("input_mask: %s" % " ".join([str(x) for x in input_mask]))
       tf.logging.info(

--- a/extract_features.py
+++ b/extract_features.py
@@ -77,6 +77,10 @@ flags.DEFINE_bool(
     "tf.nn.embedding_lookup will be used. On TPUs, this should be True "
     "since it is much faster.")
 
+flags.DEFINE_bool(
+    "only_cls_features", False,
+    "If True, only the features for the CLS tokens will be extracted")
+
 
 class InputExample(object):
 
@@ -170,8 +174,8 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
 
     tvars = tf.trainable_variables()
     scaffold_fn = None
-    (assignment_map, _) = modeling.get_assignment_map_from_checkpoint(
-        tvars, init_checkpoint)
+    (assignment_map, initialized_variable_names
+    ) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)
     if use_tpu:
 
       def tpu_scaffold():
@@ -181,6 +185,14 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
       scaffold_fn = tpu_scaffold
     else:
       tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
+
+    tf.logging.info("**** Trainable Variables ****")
+    for var in tvars:
+      init_string = ""
+      if var.name in initialized_variable_names:
+        init_string = ", *INIT_FROM_CKPT*"
+      tf.logging.info("  name = %s, shape = %s%s", var.name, var.shape,
+                      init_string)
 
     all_layers = model.get_all_encoder_layers()
 
@@ -273,7 +285,8 @@ def convert_examples_to_features(examples, seq_length, tokenizer):
     if ex_index < 5:
       tf.logging.info("*** Example ***")
       tf.logging.info("unique_id: %s" % (example.unique_id))
-      tf.logging.info("tokens: %s" % " ".join([str(x) for x in tokens]))
+      tf.logging.info("tokens: %s" % " ".join(
+          [tokenization.printable_text(x) for x in tokens]))
       tf.logging.info("input_ids: %s" % " ".join([str(x) for x in input_ids]))
       tf.logging.info("input_mask: %s" % " ".join([str(x) for x in input_mask]))
       tf.logging.info(
@@ -383,6 +396,8 @@ def main(_):
       output_json["linex_index"] = unique_id
       all_features = []
       for (i, token) in enumerate(feature.tokens):
+        if FLAGS.only_cls_features and token != '[CLS]':
+          break
         all_layers = []
         for (j, layer_index) in enumerate(layer_indexes):
           layer_output = result["layer_output_%d" % j]

--- a/extract_features.py
+++ b/extract_features.py
@@ -174,7 +174,8 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
 
     tvars = tf.trainable_variables()
     scaffold_fn = None
-    (assignment_map, initialized_variable_names) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)
+    (assignment_map, _) = modeling.get_assignment_map_from_checkpoint(
+        tvars, init_checkpoint)
     if use_tpu:
 
       def tpu_scaffold():


### PR DESCRIPTION
This flag helps reducing the file size when only the feature for the [CLS] token is needed. For example, to use BERT to extract paragraph vectors only.