### PR TITLE
fix tokenization_test

### DIFF
--- a/tokenization_test.py
+++ b/tokenization_test.py
@@ -30,7 +30,7 @@ class TokenizationTest(tf.test.TestCase):
         "[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn",
         "##ing", ","
     ]
-    with tempfile.NamedTemporaryFile(delete=False) as vocab_writer:
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as vocab_writer:
       vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
       vocab_file = vocab_writer.name


### PR DESCRIPTION
tokenization_test currently fails because the NamedTemporaryFile is opened as a binary file, but the vocab is written as text.