### PR TITLE
define the variable before assinment to work without init_checkpoint

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -609,6 +609,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
     tvars = tf.trainable_variables()
 
     scaffold_fn = None
+    initialized_variable_names = []
     if init_checkpoint:
       (assignment_map, initialized_variable_names
       ) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)


### PR DESCRIPTION
Currently, run_classifier.py fails without --init_checkpoint option:

```
  File "bert/run_classifier.py", line 628, in model_fn
    if var.name in initialized_variable_names:
UnboundLocalError: local variable 'initialized_variable_names' referenced before assignment
```

The patch allows to work it.