### PR TITLE
Define initialized_variable_names even if init_checkpoint is None

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -609,6 +609,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
     tvars = tf.trainable_variables()
 
     scaffold_fn = None
+    initialized_variable_names = []
     if init_checkpoint:
       (assignment_map, initialized_variable_names
       ) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)


### PR DESCRIPTION
In the function `run_classifier.model_fn_builder`, when `init_checkpoint` is `None`, variable `initialized_variable_names` will not be defined, but it is used later.

This commit fixes this by defining the initial value of it to be `[]`.