### PR TITLE
fix boundary checking bug

### DIFF
--- a/run_squad.py
+++ b/run_squad.py
@@ -412,9 +412,7 @@ def convert_examples_to_features(examples, tokenizer, max_seq_length,
         doc_start = doc_span.start
         doc_end = doc_span.start + doc_span.length - 1
         out_of_span = False
-        if (example.start_position < doc_start or
-            example.end_position < doc_start or
-            example.start_position > doc_end or example.end_position > doc_end):
+        if not (tok_start_position >= doc_start and tok_end_position <= doc_end):
           out_of_span = True
         if out_of_span:
           start_position = 0


### PR DESCRIPTION
`example.start_position` is the index of whitespace separated tokens, while `doc_start` is the index of BPE tokens. Therefore, it is incorrect to compare `example.start_position` and `doc_start` directly.