### PR TITLE
Fix typo in modeling.py

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -139,7 +139,7 @@ class BertModel(object):
 
     Args:
       config: `BertConfig` instance.
-      is_training: bool. rue for training model, false for eval model. Controls
+      is_training: bool. true for training model, false for eval model. Controls
         whether dropout will be applied.
       input_ids: int32 Tensor of shape [batch_size, seq_length].
       input_mask: (optional) int32 Tensor of shape [batch_size, seq_length].

--- a/modeling.py
+++ b/modeling.py
@@ -139,7 +139,7 @@ class BertModel(object):
 
     Args:
       config: `BertConfig` instance.
-      is_training: bool. true for training model, false for eval model. Controls
+      is_training: bool. True for training model, False for eval model. Controls
         whether dropout will be applied.
       input_ids: int32 Tensor of shape [batch_size, seq_length].
       input_mask: (optional) int32 Tensor of shape [batch_size, seq_length].


### PR DESCRIPTION
fix a typo here
"is_training: bool. rue for training model, false for eval model. Controls  whether dropout will be applied." =>"is_training: bool. true for training model, false for eval model. Controls  whether dropout will be applied."