### PR TITLE
West -> West Frisian

### DIFF
--- a/multilingual.md
+++ b/multilingual.md
@@ -297,7 +297,7 @@ chosen because they are the top 100 languages with the largest Wikipedias:
 *   Volapük
 *   Waray-Waray
 *   Welsh
-*   West
+*   West Frisian
 *   Western Punjabi
 *   Yoruba
 


### PR DESCRIPTION
The language "West" does not exist, probably a splitting error. Candidates are "West Frisian" and "West Flemish". The West Frisian Wikipedia is much larger than the West Flemish one, so West Frisian should be the correct one.