### PR TITLE
Added option to use Universal Transformer with bert

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -77,6 +77,8 @@ flags.DEFINE_bool(
     "tf.nn.embedding_lookup will be used. On TPUs, this should be True "
     "since it is much faster.")
 
+flags.DEFINE_bool("universal", False, "use universal transformer")
+
 
 class InputExample(object):
 
@@ -163,7 +165,8 @@ def model_fn_builder(bert_config, init_checkpoint, layer_indexes, use_tpu,
         input_ids=input_ids,
         input_mask=input_mask,
         token_type_ids=input_type_ids,
-        use_one_hot_embeddings=use_one_hot_embeddings)
+        use_one_hot_embeddings=use_one_hot_embeddings,
+        universal=FLAGS.universal)
 
     if mode != tf.estimator.ModeKeys.PREDICT:
       raise ValueError("Only PREDICT modes are supported: %s" % (mode))
@@ -344,6 +347,9 @@ def main(_):
   tf.logging.set_verbosity(tf.logging.INFO)
 
   layer_indexes = [int(x) for x in FLAGS.layers.split(",")]
+
+  if layer_indexes != [-1] and FLAGS.universal==True:
+    raise ValueError("must set --layers=-1 when using Universal Transformer as it only has 1 layer")
 
   bert_config = modeling.BertConfig.from_json_file(FLAGS.bert_config_file)
 

--- a/run_classifier.py
+++ b/run_classifier.py
@@ -123,6 +123,9 @@ flags.DEFINE_integer(
     "num_tpu_cores", 8,
     "Only used if `use_tpu` is True. Total number of TPU cores to use.")
 
+flags.DEFINE_bool("universal", False, "use universal transformer")
+
+
 
 class InputExample(object):
   """A single training/test example for simple sequence classification."""
@@ -547,7 +550,8 @@ def create_model(bert_config, is_training, input_ids, input_mask, segment_ids,
       input_ids=input_ids,
       input_mask=input_mask,
       token_type_ids=segment_ids,
-      use_one_hot_embeddings=use_one_hot_embeddings)
+      use_one_hot_embeddings=use_one_hot_embeddings,
+      universal=False)
 
   # In the demo, we are doing a simple classification task on the entire
   # segment.


### PR DESCRIPTION
#### Added option to use Universal Transformer with an adaptive computation time mechanism as described in https://arxiv.org/abs/1807.03819 and implemented in Tenstor2Tensor. 

##### usage example:
```
python run_pretraining.py \
  --input_file=/tmp/tf_examples.tfrecord \
  --output_dir=/tmp/pretraining_output \
  --do_train=True \
  --do_eval=True \
  --bert_config_file=$BERT_BASE_DIR/bert_config.json \
  --init_checkpoint=$BERT_BASE_DIR/bert_model.ckpt \
  --train_batch_size=32 \
  --max_seq_length=128 \
  --max_predictions_per_seq=20 \
  --num_train_steps=20 \
  --num_warmup_steps=10 \
 --universal=True \
  --learning_rate=2e-5

``` 

```
python extract_features.py \
  --input_file=/tmp/input.txt \
  --output_file=/tmp/output.jsonl \
  --vocab_file=$BERT_BASE_DIR/vocab.txt \
  --bert_config_file=$BERT_BASE_DIR/bert_config.json \
  --init_checkpoint=$BERT_BASE_DIR/bert_model.ckpt \
  --layers=-1 \
  --max_seq_length=128 \
  --batch_size=8
```

Please note that `--layers=-1` is mandatory as the universal transformer only has 1 (recurrent) layer.