### PR TITLE
Updated tokenization_test to use write mode for tmp file

### DIFF
--- a/tokenization_test.py
+++ b/tokenization_test.py
@@ -30,7 +30,7 @@ class TokenizationTest(tf.test.TestCase):
         "[UNK]", "[CLS]", "[SEP]", "want", "##want", "##ed", "wa", "un", "runn",
         "##ing", ","
     ]
-    with tempfile.NamedTemporaryFile(delete=False) as vocab_writer:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as vocab_writer:
       vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
       vocab_file = vocab_writer.name


### PR DESCRIPTION
This test was defaulting to a binary mode for the temporary named file which was causing it to fail in python 3. I've updated it to use the write mode