### PR TITLE
Fix documentation (the number of parameters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ especially on languages with non-Latin alphabets.**
 This does not require any code changes, and can be downloaded here:
 
 *   **[`BERT-Base, Multilingual Cased`](https://storage.googleapis.com/bert_models/2018_11_23/multi_cased_L-12_H-768_A-12.zip)**:
-    104 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    104 languages, 12-layer, 768-hidden, 12-heads, 179M parameters
 
 **\*\*\*\*\* New November 15th, 2018: SOTA SQuAD 2.0 System \*\*\*\*\***
 
@@ -40,9 +40,9 @@ We have made two new BERT models available:
 
 *   **[`BERT-Base, Multilingual`](https://storage.googleapis.com/bert_models/2018_11_03/multilingual_L-12_H-768_A-12.zip)
     (Not recommended, use `Multilingual Cased` instead)**: 102 languages,
-    12-layer, 768-hidden, 12-heads, 110M parameters
+    12-layer, 768-hidden, 12-heads, 168M parameters
 *   **[`BERT-Base, Chinese`](https://storage.googleapis.com/bert_models/2018_11_03/chinese_L-12_H-768_A-12.zip)**:
-    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 110M
+    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 103M
     parameters
 
 We use character-based tokenization for Chinese, and WordPiece tokenization for
@@ -222,18 +222,18 @@ The links to the models are here (right-click, 'Save link as...' on the name):
 *   **[`BERT-Base, Uncased`](https://storage.googleapis.com/bert_models/2018_10_18/uncased_L-12_H-768_A-12.zip)**:
     12-layer, 768-hidden, 12-heads, 110M parameters
 *   **[`BERT-Large, Uncased`](https://storage.googleapis.com/bert_models/2018_10_18/uncased_L-24_H-1024_A-16.zip)**:
-    24-layer, 1024-hidden, 16-heads, 340M parameters
+    24-layer, 1024-hidden, 16-heads, 336M parameters
 *   **[`BERT-Base, Cased`](https://storage.googleapis.com/bert_models/2018_10_18/cased_L-12_H-768_A-12.zip)**:
-    12-layer, 768-hidden, 12-heads , 110M parameters
+    12-layer, 768-hidden, 12-heads , 109M parameters
 *   **[`BERT-Large, Cased`](https://storage.googleapis.com/bert_models/2018_10_18/cased_L-24_H-1024_A-16.zip)**:
-    24-layer, 1024-hidden, 16-heads, 340M parameters
+    24-layer, 1024-hidden, 16-heads, 335M parameters
 *   **[`BERT-Base, Multilingual Cased (New, recommended)`](https://storage.googleapis.com/bert_models/2018_11_23/multi_cased_L-12_H-768_A-12.zip)**:
-    104 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    104 languages, 12-layer, 768-hidden, 12-heads, 179M parameters
 *   **[`BERT-Base, Multilingual Uncased (Orig, not recommended)`](https://storage.googleapis.com/bert_models/2018_11_03/multilingual_L-12_H-768_A-12.zip)
     (Not recommended, use `Multilingual Cased` instead)**: 102 languages,
-    12-layer, 768-hidden, 12-heads, 110M parameters
+    12-layer, 768-hidden, 12-heads, 168M parameters
 *   **[`BERT-Base, Chinese`](https://storage.googleapis.com/bert_models/2018_11_03/chinese_L-12_H-768_A-12.zip)**:
-    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 110M
+    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 103M
     parameters
 
 Each .zip file contains three items:


### PR DESCRIPTION
The number of total parameters depends on vocab_size.
This PR counts the actual number of parameters contained in each pre-trained models, since their vocab_sizes are different.