### PR TITLE
Fix unnecessary reloading of the pre-trained model in EVAL and PREDICT

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -644,30 +644,6 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
         bert_config, is_training, input_ids, input_mask, segment_ids, label_ids,
         num_labels, use_one_hot_embeddings)
 
-    tvars = tf.trainable_variables()
-    initialized_variable_names = {}
-    scaffold_fn = None
-    if init_checkpoint:
-      (assignment_map, initialized_variable_names
-      ) = modeling.get_assignment_map_from_checkpoint(tvars, init_checkpoint)
-      if use_tpu:
-
-        def tpu_scaffold():
-          tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
-          return tf.train.Scaffold()
-
-        scaffold_fn = tpu_scaffold
-      else:
-        tf.train.init_from_checkpoint(init_checkpoint, assignment_map)
-
-    tf.logging.info("**** Trainable Variables ****")
-    for var in tvars:
-      init_string = ""
-      if var.name in initialized_variable_names:
-        init_string = ", *INIT_FROM_CKPT*"
-      tf.logging.info("  name = %s, shape = %s%s", var.name, var.shape,
-                      init_string)
-
     output_spec = None
     if mode == tf.estimator.ModeKeys.TRAIN:
 
@@ -677,8 +653,7 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
       output_spec = tf.contrib.tpu.TPUEstimatorSpec(
           mode=mode,
           loss=total_loss,
-          train_op=train_op,
-          scaffold_fn=scaffold_fn)
+          train_op=train_op)
     elif mode == tf.estimator.ModeKeys.EVAL:
 
       def metric_fn(per_example_loss, label_ids, logits, is_real_example):
@@ -696,13 +671,11 @@ def model_fn_builder(bert_config, num_labels, init_checkpoint, learning_rate,
       output_spec = tf.contrib.tpu.TPUEstimatorSpec(
           mode=mode,
           loss=total_loss,
-          eval_metrics=eval_metrics,
-          scaffold_fn=scaffold_fn)
+          eval_metrics=eval_metrics)
     else:
       output_spec = tf.contrib.tpu.TPUEstimatorSpec(
           mode=mode,
-          predictions={"probabilities": probabilities},
-          scaffold_fn=scaffold_fn)
+          predictions={"probabilities": probabilities})
     return output_spec
 
   return model_fn
@@ -877,7 +850,31 @@ def main(_):
         seq_length=FLAGS.max_seq_length,
         is_training=True,
         drop_remainder=True)
-    estimator.train(input_fn=train_input_fn, max_steps=num_train_steps)
+
+
+    #
+    # We use a SessionRunHook to load the pre-trained BERT model. This is only needed in the training phase.
+    #
+    class InitHooks(tf.train.SessionRunHook):
+        def __init__(self, init_checkpoint=None):
+            self._init_checkpoint = init_checkpoint
+
+        def begin(self):
+            tvars = tf.trainable_variables()
+            initialized_variable_names = {}
+
+            (assignment_map, initialized_variable_names) = modeling.get_assignment_map_from_checkpoint(tvars, self._init_checkpoint)
+            tf.train.init_from_checkpoint(self._init_checkpoint, assignment_map)
+            tf.logging.info("**** Trainable Variables ****")
+            for var in tvars:
+                init_string = ""
+                if var.name in initialized_variable_names:
+                    init_string = ", *INIT_FROM_CKPT*"
+                tf.logging.info("  name = %s, shape = %s%s", var.name, var.shape,
+                                init_string)
+
+    
+    estimator.train(input_fn=train_input_fn, hooks=[InitHooks(FLAGS.init_checkpoint)], max_steps=num_train_steps)
 
   if FLAGS.do_eval:
     eval_examples = processor.get_dev_examples(FLAGS.data_dir)


### PR DESCRIPTION
In the current implementation, the pre-trained model will be loaded not only in TRAIN, but also in EVAL and PREDICT.
This is not necessary as the weights will be overwritten anyway when the Estimator framework loads previous check points from TRAIN in EVAL and PREDICT phases.

A RunHook was used to provide a clean solution to load the pre-trained model, as in this way the model_fn() is left with only the graph construction code. By passing the RunHook to estimator.train(), it ensures the pre-trained model gets loaded only during TRAIN. Since the RunHook will run on CPU, there's no longer needs for scaffolding, either.