### PR TITLE
fix issue when all n best predictions are null on squad 2.0

### DIFF
--- a/run_squad.py
+++ b/run_squad.py
@@ -903,9 +903,14 @@ def write_predictions(all_examples, all_features, all_results, n_best_size,
       all_predictions[example.qas_id] = nbest_json[0]["text"]
     else:
       # predict "" iff the null score - the score of best non-null > threshold
-      score_diff = score_null - best_non_null_entry.start_logit - (
-          best_non_null_entry.end_logit)
-      scores_diff_json[example.qas_id] = score_diff
+      if best_non_null_entry:
+        score_diff = score_null - best_non_null_entry.start_logit - (
+            best_non_null_entry.end_logit)
+        scores_diff_json[example.qas_id] = score_diff
+      else:
+        # all n best entries are null, we assign a higher diff than threshold
+        score_diff = FLAGS.null_score_diff_threshold + 1.0
+
       if score_diff > FLAGS.null_score_diff_threshold:
         all_predictions[example.qas_id] = ""
       else:


### PR DESCRIPTION
fix issue #476 , #211.

If all n best predictions are null, we would get 'None' for best_non_null_entry and the program will crash in the next few lines.
