### PR TITLE
Fix bug on extract_features.py in condition of use_cpu=True

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -379,7 +379,8 @@ def main(_):
       use_tpu=FLAGS.use_tpu,
       model_fn=model_fn,
       config=run_config,
-      predict_batch_size=FLAGS.batch_size)
+      predict_batch_size=FLAGS.batch_size,
+      train_batch_size=FLAGS.batch_size)
 
   input_fn = input_fn_builder(
       features=features, seq_length=FLAGS.max_seq_length)


### PR DESCRIPTION
# Problem
We cannot run `extract_features.py` in condition of  `use_tpu = True` as below.

![image](https://user-images.githubusercontent.com/22956498/54874280-2dc5aa80-4e2b-11e9-87f0-c4373ac5dacf.png)

# Reason
This is because of the lack of an argument `train_batch_size` on TPUEstimator.
The necessity of the argument is described [on its code](https://github.com/tensorflow/tensorflow/blob/6612da89516247503f03ef76e974b51a434fb52e/tensorflow/contrib/tpu/python/tpu/tpu_estimator.py#L2111-L2115
).

# Fixing
I added the argument on it.
This fixing works successfully as below.

![image](https://user-images.githubusercontent.com/22956498/54874541-c14daa00-4e30-11e9-9167-3aa11ff581a0.png)




