### PR TITLE
Removed redudant code from create_pretraining_data.py

### DIFF
--- a/create_pretraining_data.py
+++ b/create_pretraining_data.py
@@ -353,13 +353,9 @@ def create_masked_lm_predictions(tokens, masked_lm_prob,
                        max(1, int(round(len(tokens) * masked_lm_prob))))
 
   masked_lms = []
-  covered_indexes = set()
   for index in cand_indexes:
     if len(masked_lms) >= num_to_predict:
       break
-    if index in covered_indexes:
-      continue
-    covered_indexes.add(index)
 
     masked_token = None
     # 80% of the time, replace with [MASK]


### PR DESCRIPTION
The variable `covered_indexes` in the function `create_masked_lm_predictions` seems redundant, since `cand_indexes` is a list of unique indexes. In addition, the indexes to cover are selected sequentially, starting from the beginning of the shuffled `cand_indexes`. Therefore, it is not clear why it is needed to avoid duplicates of covered indexes.