### PR TITLE
allow tfhub classifier to run just predictions without raising and error

### DIFF
--- a/run_classifier_with_tfhub.py
+++ b/run_classifier_with_tfhub.py
@@ -164,8 +164,8 @@ def main(_):
       "mrpc": run_classifier.MrpcProcessor,
   }
 
-  if not FLAGS.do_train and not FLAGS.do_eval:
-    raise ValueError("At least one of `do_train` or `do_eval` must be True.")
+  if not FLAGS.do_train and not FLAGS.do_eval and not FLAGS.do_predict:
+    raise ValueError("`do_train`, `do_eval`, or `do_predict` must be True.")
 
   tf.gfile.MakeDirs(FLAGS.output_dir)
 


### PR DESCRIPTION
Added FLAGS.do_predict to FLAGS.do_train and FLAGS.do_eval in the conditional error check in order to run only predictions on test data. Elsewhere in the file, and in run_classifier.py, you had to have one of the three options.