### PR TITLE
The masked token should not be the marking token

### DIFF
--- a/create_pretraining_data.py
+++ b/create_pretraining_data.py
@@ -398,8 +398,12 @@ def create_masked_lm_predictions(tokens, masked_lm_prob,
           masked_token = tokens[index]
         # 10% of the time, replace with random word
         else:
-          masked_token = vocab_words[rng.randint(0, len(vocab_words) - 1)]
-
+          # Make sure that the random word is not the marking token such as "[CLS]"
+          while True:
+            masked_token = vocab_words[rng.randint(0, len(vocab_words) - 1)]
+            if masked_token != "[CLS]" and masked_token != "[SEP]":
+              break
+              
       output_tokens[index] = masked_token
 
       masked_lms.append(MaskedLmInstance(index=index, label=tokens[index]))


### PR DESCRIPTION
When doing pretraining for another corpus, I found that sometimes the code would generate some instances replacing the masked token with the marking word "[SEP]" or "[CLS]", I don't think it is right to add these instances into the pretraining process because I think [SEP] and [CLS] shouldn't learn from MLM though the number of these instances is small. So I made the fix. 