### PR TITLE
Add explicit tensorflow version to predicting_movie_reviews_with_bert…

### DIFF
--- a/predicting_movie_reviews_with_bert_on_tf_hub.ipynb
+++ b/predicting_movie_reviews_with_bert_on_tf_hub.ipynb
@@ -74,6 +74,7 @@
       "source": [
         "from sklearn.model_selection import train_test_split\n",
         "import pandas as pd\n",
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "import tensorflow_hub as hub\n",
         "from datetime import datetime"


### PR DESCRIPTION
…_on_tf_hub.ipynb

Colab will soon update the default version of tensorflow to 2.1.0. In order for this notebook to continue to work, I'm adding a line magic that will ensure this notebook continues to use tensorflow 1.x and execute without errors.