### PR TITLE
fix korean tokenization bug

### DIFF
--- a/tokenization.py
+++ b/tokenization.py
@@ -226,7 +226,8 @@ class BasicTokenizer(object):
       if cat == "Mn":
         continue
       output.append(char)
-    return "".join(output)
+    res = "".join(output)
+    return unicodedata.normalize("NFC", res)
 
   def _run_split_on_punc(self, text):
     """Splits punctuation on a piece of text."""


### PR DESCRIPTION
when do_lower_case = True, Languages like Korean will lead to a bunch of [UNK].eg:
한국어 ->  ᄒ ᅡ ᆫ ᄀ ᅮ ᆨ ᄋ ᅥ
just transfer NFD back to NFC when return.
Just one line insertion can neatly solve this bug. For all languages could have this problem.