### PR TITLE
Update dropout layer to be compatible with TF1 and TF2.

### DIFF
--- a/modeling.py
+++ b/modeling.py
@@ -346,8 +346,7 @@ def dropout(input_tensor, dropout_prob):
 
   Args:
     input_tensor: float Tensor.
-    dropout_prob: Python float. The probability of dropping out a value (NOT of
-      *keeping* a dimension as in `tf.nn.dropout`).
+    dropout_prob: Python float. The probability of dropping out a value.
 
   Returns:
     A version of `input_tensor` with dropout applied.
@@ -355,7 +354,7 @@ def dropout(input_tensor, dropout_prob):
   if dropout_prob is None or dropout_prob == 0.0:
     return input_tensor
 
-  output = tf.nn.dropout(input_tensor, 1.0 - dropout_prob)
+  output = tf.nn.dropout(input_tensor, rate=dropout_prob)
   return output
 
 


### PR DESCRIPTION
The function signature for tf.nn.dropout in TF1 is:
```python
tf.nn.dropout(
    x,
    keep_prob=None,
    noise_shape=None,
    seed=None,
    name=None,
    rate=None
)
```

while TF2 has:
```python
tf.nn.dropout(
    x, rate, noise_shape=None, seed=None, name=None
)
```
Using the `rate` keyword argument is compatible with both, and less confusing.