### PR TITLE
solved a bug in run_squad.py when len(nbest)==1

### DIFF
--- a/run_squad.py
+++ b/run_squad.py
@@ -885,6 +885,8 @@ def write_predictions(all_examples, all_features, all_results, n_best_size,
       if not best_non_null_entry:
         if entry.text:
           best_non_null_entry = entry
+    if not best_non_null_entry:
+      best_non_null_entry = nbest[0]
 
     probs = _compute_softmax(total_scores)
 


### PR DESCRIPTION
I was fine-tunning base BERT on squad 2.0. 
I ran the training on Tesla P40 & was able to finish it with below settings

```
nohup python run_squad.py \
  --vocab_file=$BERT_BASE_DIR/vocab.txt \
  --bert_config_file=$BERT_BASE_DIR/bert_config.json \
  --init_checkpoint=$BERT_BASE_DIR/bert_model.ckpt \
  --do_train=True \
  --train_file=$SQUAD_DIR/train-v2.0.json \
  --do_predict=True \
  --predict_file=$SQUAD_DIR/dev-v2.0.json \
  --train_batch_size=12 \
  --learning_rate=3e-5 \
  --num_train_epochs=2.0 \
  --max_seq_length=512 \
  --doc_stride=128 \
  --output_dir=outputs/base_L512_B12/ \
  --version_2_with_negative=True &
```
After the training, i calculated the threshold, which came around -1.613877

& Finally I ran evaluate.py to get the final F1 score as below:

```
python run_squad.py \
  --vocab_file=$BERT_BASE_DIR/vocab.txt \
  --bert_config_file=$BERT_BASE_DIR/bert_config.json \
  --init_checkpoint=$BERT_BASE_DIR/bert_model.ckpt \
  --do_train=False \
  --train_file=$SQUAD_DIR/train-v2.0.json \
  --do_predict=True \
  --predict_file=$SQUAD_DIR/dev-v2.0.json \
  --train_batch_size=12 \
  --learning_rate=3e-5 \
  --num_train_epochs=2.0 \
  --max_seq_length=512 \
  --doc_stride=128 \
  --output_dir=outputs/base_L512_B12_THRESH/ \
  --version_2_with_negative=True \
  --null_score_diff_threshold=$THRESH
```

But the run_squad.py was throwing below error:

> AttributeError: 'NoneType' object has no attribute 'start_logit'

After some debugging, the issue was as below:

```
best_non_null_entry = None
    for entry in nbest:
      total_scores.append(entry.start_logit + entry.end_logit)
      if not best_non_null_entry:
        if entry.text:
          best_non_null_entry = entry
```
In the above snippet, BERT Base was generating only one nbest entry with empty text, due to which best_non_null_entry used to stay None & was causing an error while calculating score_diff as below

```
score_diff = score_null - best_non_null_entry.start_logit - (
          best_non_null_entry.end_logit)
```

I think this is a very peculiar scenario that only happens while using BERT Base as it generates only one nbest entry with the blank text for few questions but needs to be fixed nonetheless.

