### PR TITLE
Update tokenization.py

### DIFF
--- a/tokenization.py
+++ b/tokenization.py
@@ -122,7 +122,7 @@ def load_vocab(vocab_file):
   """Loads a vocabulary file into a dictionary."""
   vocab = collections.OrderedDict()
   index = 0
-  with tf.gfile.GFile(vocab_file, "r") as reader:
+  with tf.io.gfile.GFile(vocab_file, "r") as reader:
     while True:
       token = convert_to_unicode(reader.readline())
       if not token:


### PR DESCRIPTION
In function load_vocab(vocab_file) 
tf.gfile.Gfile throws an AttributeError: module 'tensorflow' has no attribute 'gfile'

I suppose in Tensorflow 2.0 and later versions the gfile has been moved to tf.io 

hence replaced tf.gfile.Gfile with tf.io.gfile.Gfile