### PR TITLE
docs(multilingual.md): correct the number of parameters of each model

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ especially on languages with non-Latin alphabets.**
 This does not require any code changes, and can be downloaded here:
 
 *   **[`BERT-Base, Multilingual Cased`](https://storage.googleapis.com/bert_models/2018_11_23/multi_cased_L-12_H-768_A-12.zip)**:
-    104 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    104 languages, 12-layer, 768-hidden, 12-heads, 179M parameters
 
 **\*\*\*\*\* New November 15th, 2018: SOTA SQuAD 2.0 System \*\*\*\*\***
 
@@ -163,9 +163,9 @@ We have made two new BERT models available:
 
 *   **[`BERT-Base, Multilingual`](https://storage.googleapis.com/bert_models/2018_11_03/multilingual_L-12_H-768_A-12.zip)
     (Not recommended, use `Multilingual Cased` instead)**: 102 languages,
-    12-layer, 768-hidden, 12-heads, 110M parameters
+    12-layer, 768-hidden, 12-heads, 168M parameters
 *   **[`BERT-Base, Chinese`](https://storage.googleapis.com/bert_models/2018_11_03/chinese_L-12_H-768_A-12.zip)**:
-    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 110M
+    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 103M
     parameters
 
 We use character-based tokenization for Chinese, and WordPiece tokenization for
@@ -355,12 +355,12 @@ The links to the models are here (right-click, 'Save link as...' on the name):
 *   **[`BERT-Large, Cased`](https://storage.googleapis.com/bert_models/2018_10_18/cased_L-24_H-1024_A-16.zip)**:
     24-layer, 1024-hidden, 16-heads, 340M parameters
 *   **[`BERT-Base, Multilingual Cased (New, recommended)`](https://storage.googleapis.com/bert_models/2018_11_23/multi_cased_L-12_H-768_A-12.zip)**:
-    104 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    104 languages, 12-layer, 768-hidden, 12-heads, 179M parameters
 *   **[`BERT-Base, Multilingual Uncased (Orig, not recommended)`](https://storage.googleapis.com/bert_models/2018_11_03/multilingual_L-12_H-768_A-12.zip)
     (Not recommended, use `Multilingual Cased` instead)**: 102 languages,
-    12-layer, 768-hidden, 12-heads, 110M parameters
+    12-layer, 768-hidden, 12-heads, 168M parameters
 *   **[`BERT-Base, Chinese`](https://storage.googleapis.com/bert_models/2018_11_03/chinese_L-12_H-768_A-12.zip)**:
-    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 110M
+    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 103M
     parameters
 
 Each .zip file contains three items:

--- a/multilingual.md
+++ b/multilingual.md
@@ -5,11 +5,11 @@ more single-language models, but we may release `BERT-Large` versions of these
 two in the future:
 
 *   **[`BERT-Base, Multilingual Cased (New, recommended)`](https://storage.googleapis.com/bert_models/2018_11_23/multi_cased_L-12_H-768_A-12.zip)**:
-    104 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    104 languages, 12-layer, 768-hidden, 12-heads, 179M parameters
 *   **[`BERT-Base, Multilingual Uncased (Orig, not recommended)`](https://storage.googleapis.com/bert_models/2018_11_03/multilingual_L-12_H-768_A-12.zip)**:
-    102 languages, 12-layer, 768-hidden, 12-heads, 110M parameters
+    102 languages, 12-layer, 768-hidden, 12-heads, 168M parameters
 *   **[`BERT-Base, Chinese`](https://storage.googleapis.com/bert_models/2018_11_03/chinese_L-12_H-768_A-12.zip)**:
-    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 110M
+    Chinese Simplified and Traditional, 12-layer, 768-hidden, 12-heads, 103M
     parameters
 
 **The `Multilingual Cased (New)` model also fixes normalization issues in many


### PR DESCRIPTION
@jacobdevlin-google 
The number of parameters of each multilingual model depends on the size of its vocabulary:

**BERT-Base Multilingual Cased:**
- word embeddings dimension: [119547, 768]
- number of weights (word embeddings): 91812096 (119547x768)
- total parameters: 178565115


**BERT-Base Multilingual Uncased:**
- word embeddings dimension: [105879, 768]
- number of weights (word embeddings): 81315072 (105879x768)
- total parameters: 168054423


**BERT-Base, Chinese:**
- word embeddings dimension: [21128, 768]
- number of weights (word embeddings): 16226304 (21128x768)
- total parameters: 102880904


Python code to reproduce these numbers (using huggingface *transformers* library):
```python
from transformers import AutoModelForMaskedLM

model_cased = AutoModelForMaskedLM.from_pretrained('bert-base-multilingual-cased')
model_cased.get_input_embeddings()
model_cased.num_parameters()

model_uncased = AutoModelForMaskedLM.from_pretrained('bert-base-multilingual-uncased')
model_uncased.get_input_embeddings()
model_uncased.num_parameters()

model_chinese = AutoModelForMaskedLM.from_pretrained('bert-base-chinese')
model_chinese.get_input_embeddings()
model_chinese.num_parameters()

```