### PR TITLE
Fix gfile and flags no attribute error for TensorFlow V2

### DIFF
--- a/create_pretraining_data.py
+++ b/create_pretraining_data.py
@@ -22,6 +22,9 @@ import collections
 import random
 import tokenization
 import tensorflow as tf
+if(tf.__version__.startswith("2")):
+    tf.gfile = tf.io.gfile
+    tf.flags = tf.compat.v1.flags
 
 flags = tf.flags
 


### PR DESCRIPTION
There are "no attribute" errors such as
`AttributeError: module 'tensorflow' has no attribute 'gfile'`
`AttributeError: module 'tensorflow' has no attribute 'flags'`

because tensorflow V2 is automatically installed from `pip install -r requirements.txt`.

To fix this error, I added version check code and make it works properly in TensorFlow V2 environments.

Also, TensorFlow V1 users can use this code. because if tf.__version__ is lower than 2.0.0, it will use legacy code.
